### PR TITLE
feat: add -v short flag for version

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,9 +29,12 @@ enum SortBy {
 }
 
 #[derive(Parser)]
-#[command(name = "rip")]
-#[command(about = "Fuzzy find and kill processes", long_about = None)]
+#[command(name = "rip", version, about = "Fuzzy find and kill processes", disable_version_flag = true)]
 struct Args {
+    /// Print version
+    #[arg(short = 'v', long = "version", action = clap::ArgAction::Version)]
+    _version: (),
+
     /// Pre-filter processes by name
     #[arg(short, long)]
     filter: Option<String>,


### PR DESCRIPTION
## Summary

Add `-v` as a short flag for `--version`, a common CLI convention.

## Usage

```bash
rip -v        # prints: rip 0.4.3
rip --version # prints: rip 0.4.3
```

## Test plan

- [ ] Run `rip -v` and verify version is printed
- [ ] Run `rip --version` and verify version is printed
- [ ] Run `cargo test` to verify all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)