### PR TITLE
Make rip work on Windows and add smart memory coloring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "rip-cli"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rip-cli"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Fuzzy find and kill processes from your terminal"
 license = "MIT"
@@ -15,10 +15,12 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 sysinfo = "0.32"
-nix = { version = "0.29", features = ["signal"] }
 colored = "2"
 inquire = "0.7"
 terminal_size = "0.4"
 ratatui = "0.29"
 crossterm = "0.28"
 listeners = "0.3"
+
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.29", features = ["signal"] }


### PR DESCRIPTION
I noticed that rip didn't work on Windows, so I made it work by updating dependencies. Also, I noticed that the CPU usage was smart colored, but the memory wasn't, so I implemented it for the memory usage too.
<img width="1112" height="626" alt="image" src="https://github.com/user-attachments/assets/6cbad964-1785-4b04-a92b-f79f4211619f" />